### PR TITLE
chore(deps): ⬆️ update dependencies in package.json

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -17,7 +17,7 @@
     "@acme/api": "workspace:*",
     "@acme/auth": "workspace:*",
     "@acme/db": "workspace:*",
-    "@tanstack/react-query": "^4.29.2",
+    "@tanstack/react-query": "^4.36.1",
     "@trpc/client": "^10.20.0",
     "@trpc/next": "^10.20.0",
     "@trpc/react-query": "^10.20.0",
@@ -26,18 +26,18 @@
     "next-auth": "^4.22.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "superjson": "1.9.1",
-    "zod": "^3.21.4"
+    "superjson": "2.2.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@acme/eslint-config": "workspace:*",
-    "@types/node": "^18.15.11",
-    "@types/react": "^18.0.37",
-    "@types/react-dom": "^18.0.11",
-    "autoprefixer": "^10.4.14",
-    "dotenv-cli": "^7.2.1",
+    "@types/node": "^22.5.5",
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "dotenv-cli": "^7.4.2",
     "eslint": "^8.38.0",
-    "postcss": "^8.4.22",
+    "postcss": "^8.4.47",
     "tailwindcss": "^3.4.12",
     "typescript": "^5.0.4"
   }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,8 +16,8 @@
     "@acme/db": "workspace:*",
     "@trpc/client": "^10.20.0",
     "@trpc/server": "^10.20.0",
-    "superjson": "1.9.1",
-    "zod": "^3.21.4"
+    "superjson": "2.2.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@acme/eslint-config": "workspace:*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,7 +17,7 @@
     "@prisma/client": "^4.13.0"
   },
   "devDependencies": {
-    "dotenv-cli": "^7.2.1",
+    "dotenv-cli": "^7.4.2",
     "prisma": "^4.13.0",
     "typescript": "^5.0.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: link:packages/config/eslint
       '@commitlint/cli':
         specifier: ^19.4.1
-        version: 19.5.0(@types/node@18.16.16)(typescript@5.1.3)
+        version: 19.5.0(@types/node@22.5.5)(typescript@5.1.3)
       '@commitlint/config-conventional':
         specifier: ^19.4.1
         version: 19.5.0
@@ -52,10 +52,10 @@ importers:
         version: 0.15.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.1.3)
       tailwindcss-animated:
         specifier: ^1.1.2
-        version: 1.1.2(tailwindcss@3.4.12(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3)))
+        version: 1.1.2(tailwindcss@3.4.12(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3)))
       tailwindcss-scrollbar:
         specifier: ^0.1.0
-        version: 0.1.0(tailwindcss@3.4.12(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3)))
+        version: 0.1.0(tailwindcss@3.4.12(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3)))
       turbo:
         specifier: ^2.1.2
         version: 2.1.2
@@ -75,17 +75,17 @@ importers:
         specifier: workspace:*
         version: link:../../packages/db
       '@tanstack/react-query':
-        specifier: ^4.29.2
-        version: 4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^4.36.1
+        version: 4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@trpc/client':
         specifier: ^10.20.0
         version: 10.29.1(@trpc/server@10.29.1)
       '@trpc/next':
         specifier: ^10.20.0
-        version: 10.29.1(@tanstack/react-query@4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/react-query@10.29.1(@tanstack/react-query@4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@10.29.1)(next@13.4.4(@babel/core@7.25.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 10.29.1(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/react-query@10.29.1(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@10.29.1)(next@13.4.4(@babel/core@7.25.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@trpc/react-query':
         specifier: ^10.20.0
-        version: 10.29.1(@tanstack/react-query@4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 10.29.1(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@trpc/server':
         specifier: ^10.20.0
         version: 10.29.1
@@ -102,39 +102,39 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       superjson:
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 2.2.1
+        version: 2.2.1
       zod:
-        specifier: ^3.21.4
-        version: 3.21.4
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@acme/eslint-config':
         specifier: workspace:*
         version: link:../../packages/config/eslint
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.16.16
+        specifier: ^22.5.5
+        version: 22.5.5
       '@types/react':
-        specifier: ^18.0.37
-        version: 18.2.9
+        specifier: ^18.3.8
+        version: 18.3.8
       '@types/react-dom':
-        specifier: ^18.0.11
-        version: 18.2.4
+        specifier: ^18.3.0
+        version: 18.3.0
       autoprefixer:
-        specifier: ^10.4.14
-        version: 10.4.14(postcss@8.4.24)
+        specifier: ^10.4.20
+        version: 10.4.20(postcss@8.4.47)
       dotenv-cli:
-        specifier: ^7.2.1
-        version: 7.2.1
+        specifier: ^7.4.2
+        version: 7.4.2
       eslint:
         specifier: ^8.38.0
         version: 8.42.0
       postcss:
-        specifier: ^8.4.22
-        version: 8.4.24
+        specifier: ^8.4.47
+        version: 8.4.47
       tailwindcss:
         specifier: ^3.4.12
-        version: 3.4.12(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3))
+        version: 3.4.12(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3))
       typescript:
         specifier: ^5.0.4
         version: 5.1.3
@@ -154,11 +154,11 @@ importers:
         specifier: ^10.20.0
         version: 10.29.1
       superjson:
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: 2.2.1
+        version: 2.2.1
       zod:
-        specifier: ^3.21.4
-        version: 3.21.4
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@acme/eslint-config':
         specifier: workspace:*
@@ -242,8 +242,8 @@ importers:
         version: 4.15.0(prisma@4.15.0)
     devDependencies:
       dotenv-cli:
-        specifier: ^7.2.1
-        version: 7.2.1
+        specifier: ^7.4.2
+        version: 7.4.2
       prisma:
         specifier: ^4.13.0
         version: 4.15.0
@@ -656,11 +656,11 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tanstack/query-core@4.29.11':
-    resolution: {integrity: sha512-8C+hF6SFAb/TlFZyS9FItgNwrw4PMa7YeX+KQYe2ZAiEz6uzg6yIr+QBzPkUwZ/L0bXvGd1sufTm3wotoz+GwQ==}
+  '@tanstack/query-core@4.36.1':
+    resolution: {integrity: sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==}
 
-  '@tanstack/react-query@4.29.12':
-    resolution: {integrity: sha512-zhcN6+zF6cxprxhTHQajHGlvxgK8npnp9uLe9yaWhGc6sYcPWXzyO4raL4HomUzQOPzu3jLvkriJQ7BOrDM8vA==}
+  '@tanstack/react-query@4.36.1':
+    resolution: {integrity: sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -744,20 +744,17 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@18.16.16':
-    resolution: {integrity: sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==}
+  '@types/node@22.5.5':
+    resolution: {integrity: sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==}
 
   '@types/prop-types@15.7.5':
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
 
-  '@types/react-dom@18.2.4':
-    resolution: {integrity: sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==}
+  '@types/react-dom@18.3.0':
+    resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
 
-  '@types/react@18.2.9':
-    resolution: {integrity: sha512-pL3JAesUkF7PEQGxh5XOwdXGV907te6m1/Qe1ERJLgomojS6Ne790QiA7GUl434JEkFA2aAaB6qJ5z4e1zJn/w==}
-
-  '@types/scheduler@0.16.3':
-    resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
+  '@types/react@18.3.8':
+    resolution: {integrity: sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==}
 
   '@types/semver@6.2.3':
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -921,8 +918,8 @@ packages:
   ast-types-flow@0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
 
-  autoprefixer@10.4.14:
-    resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
+  autoprefixer@10.4.20:
+    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
@@ -967,11 +964,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  browserslist@4.21.7:
-    resolution: {integrity: sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.23.3:
     resolution: {integrity: sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==}
@@ -1258,20 +1250,17 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
-  dotenv-cli@7.2.1:
-    resolution: {integrity: sha512-ODHbGTskqRtXAzZapDPvgNuDVQApu4oKX8lZW7Y0+9hKA6le1ZJlyRS687oU9FXjOVEDU/VFV6zI125HzhM1UQ==}
+  dotenv-cli@7.4.2:
+    resolution: {integrity: sha512-SbUj8l61zIbzyhIbg0FwPJq6+wjbzdn9oEtozQpZ6kW2ihCcapKVZj49oCT3oPM+mgQm+itgvUQcG5szxVrZTA==}
     hasBin: true
 
   dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
     engines: {node: '>=12'}
 
-  dotenv@16.1.4:
-    resolution: {integrity: sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==}
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
-
-  electron-to-chromium@1.4.427:
-    resolution: {integrity: sha512-HK3r9l+Jm8dYAm1ctXEWIC+hV60zfcjS9UA5BDlYvnI5S7PU/yytjpvSrTNrSSRRkuu3tDyZhdkwIczh+0DWaw==}
 
   electron-to-chromium@1.5.27:
     resolution: {integrity: sha512-o37j1vZqCoEgBuWWXLHQgTN/KDKe7zwpiY5CPeq2RvUqOyJw9xnrULzZAEVQ5p4h+zjMk7hgtOoPdnLxr7m/jw==}
@@ -1528,8 +1517,8 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
-  fraction.js@4.2.0:
-    resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
+  fraction.js@4.3.7:
+    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
@@ -2173,6 +2162,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
 
@@ -2207,9 +2201,6 @@ packages:
         optional: true
       sass:
         optional: true
-
-  node-releases@2.0.12:
-    resolution: {integrity: sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==}
 
   node-releases@2.0.18:
     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
@@ -2449,8 +2440,8 @@ packages:
     resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.4.24:
-    resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
+  postcss@8.4.47:
+    resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact-render-to-string@5.2.6:
@@ -2754,6 +2745,10 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   spawndamnit@2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
 
@@ -2840,9 +2835,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  superjson@1.9.1:
-    resolution: {integrity: sha512-oT3HA2nPKlU1+5taFgz/HDy+GEaY+CWEbLzaRJVD4gZ7zMVVC4GDNFdgvAZt6/VuIk6D2R7RtPAiCHwmdzlMmg==}
-    engines: {node: '>=10'}
+  superjson@2.2.1:
+    resolution: {integrity: sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==}
+    engines: {node: '>=16'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -3009,6 +3004,9 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -3023,12 +3021,6 @@ packages:
   untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
-
-  update-browserslist-db@1.0.11:
-    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   update-browserslist-db@1.1.0:
     resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
@@ -3143,6 +3135,9 @@ packages:
   zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
 
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -3159,7 +3154,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.0
+      picocolors: 1.1.0
 
   '@babel/compat-data@7.25.4': {}
 
@@ -3246,7 +3241,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.0
+      picocolors: 1.1.0
 
   '@babel/parser@7.25.6':
     dependencies:
@@ -3280,11 +3275,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
-  '@commitlint/cli@19.5.0(@types/node@18.16.16)(typescript@5.1.3)':
+  '@commitlint/cli@19.5.0(@types/node@22.5.5)(typescript@5.1.3)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.5.0
-      '@commitlint/load': 19.5.0(@types/node@18.16.16)(typescript@5.1.3)
+      '@commitlint/load': 19.5.0(@types/node@22.5.5)(typescript@5.1.3)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.0
@@ -3331,7 +3326,7 @@ snapshots:
       '@commitlint/rules': 19.5.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.5.0(@types/node@18.16.16)(typescript@5.1.3)':
+  '@commitlint/load@19.5.0(@types/node@22.5.5)(typescript@5.1.3)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
@@ -3339,7 +3334,7 @@ snapshots:
       '@commitlint/types': 19.5.0
       chalk: 5.3.0
       cosmiconfig: 9.0.0(typescript@5.1.3)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@18.16.16)(cosmiconfig@9.0.0(typescript@5.1.3))(typescript@5.1.3)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@22.5.5)(cosmiconfig@9.0.0(typescript@5.1.3))(typescript@5.1.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -3577,7 +3572,7 @@ snapshots:
       fast-glob: 3.2.12
       is-glob: 4.0.3
       open: 9.1.0
-      picocolors: 1.0.0
+      picocolors: 1.1.0
       tslib: 2.5.3
 
   '@pnpm/config.env-replace@1.1.0': {}
@@ -3618,11 +3613,11 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/query-core@4.29.11': {}
+  '@tanstack/query-core@4.36.1': {}
 
-  '@tanstack/react-query@4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tanstack/query-core': 4.29.11
+      '@tanstack/query-core': 4.36.1
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     optionalDependencies:
@@ -3632,20 +3627,20 @@ snapshots:
     dependencies:
       '@trpc/server': 10.29.1
 
-  '@trpc/next@10.29.1(@tanstack/react-query@4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/react-query@10.29.1(@tanstack/react-query@4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@10.29.1)(next@13.4.4(@babel/core@7.25.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@trpc/next@10.29.1(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/react-query@10.29.1(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@10.29.1)(next@13.4.4(@babel/core@7.25.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tanstack/react-query': 4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-query': 4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@trpc/client': 10.29.1(@trpc/server@10.29.1)
-      '@trpc/react-query': 10.29.1(@tanstack/react-query@4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@trpc/react-query': 10.29.1(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@trpc/server': 10.29.1
       next: 13.4.4(@babel/core@7.25.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-ssr-prepass: 1.5.0(react@18.2.0)
 
-  '@trpc/react-query@10.29.1(@tanstack/react-query@4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@trpc/react-query@10.29.1(@tanstack/react-query@4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.29.1(@trpc/server@10.29.1))(@trpc/server@10.29.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tanstack/react-query': 4.29.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-query': 4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@trpc/client': 10.29.1(@trpc/server@10.29.1)
       '@trpc/server': 10.29.1
       react: 18.2.0
@@ -3667,7 +3662,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
-      '@types/node': 18.16.16
+      '@types/node': 22.5.5
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3698,21 +3693,20 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@18.16.16': {}
+  '@types/node@22.5.5':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/prop-types@15.7.5': {}
 
-  '@types/react-dom@18.2.4':
+  '@types/react-dom@18.3.0':
     dependencies:
-      '@types/react': 18.2.9
+      '@types/react': 18.3.8
 
-  '@types/react@18.2.9':
+  '@types/react@18.3.8':
     dependencies:
       '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.3
       csstype: 3.1.2
-
-  '@types/scheduler@0.16.3': {}
 
   '@types/semver@6.2.3': {}
 
@@ -3909,14 +3903,14 @@ snapshots:
 
   ast-types-flow@0.0.7: {}
 
-  autoprefixer@10.4.14(postcss@8.4.24):
+  autoprefixer@10.4.20(postcss@8.4.47):
     dependencies:
-      browserslist: 4.21.7
-      caniuse-lite: 1.0.30001497
-      fraction.js: 4.2.0
+      browserslist: 4.23.3
+      caniuse-lite: 1.0.30001662
+      fraction.js: 4.3.7
       normalize-range: 0.1.2
-      picocolors: 1.0.0
-      postcss: 8.4.24
+      picocolors: 1.1.0
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.5: {}
@@ -3951,13 +3945,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  browserslist@4.21.7:
-    dependencies:
-      caniuse-lite: 1.0.30001497
-      electron-to-chromium: 1.4.427
-      node-releases: 2.0.12
-      update-browserslist-db: 1.0.11(browserslist@4.21.7)
 
   browserslist@4.23.3:
     dependencies:
@@ -4104,9 +4091,9 @@ snapshots:
     dependencies:
       is-what: 4.1.15
 
-  cosmiconfig-typescript-loader@5.0.0(@types/node@18.16.16)(cosmiconfig@9.0.0(typescript@5.1.3))(typescript@5.1.3):
+  cosmiconfig-typescript-loader@5.0.0(@types/node@22.5.5)(cosmiconfig@9.0.0(typescript@5.1.3))(typescript@5.1.3):
     dependencies:
-      '@types/node': 18.16.16
+      '@types/node': 22.5.5
       cosmiconfig: 9.0.0(typescript@5.1.3)
       jiti: 1.21.6
       typescript: 5.1.3
@@ -4240,18 +4227,16 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
-  dotenv-cli@7.2.1:
+  dotenv-cli@7.4.2:
     dependencies:
       cross-spawn: 7.0.3
-      dotenv: 16.1.4
+      dotenv: 16.4.5
       dotenv-expand: 10.0.0
       minimist: 1.2.8
 
   dotenv-expand@10.0.0: {}
 
-  dotenv@16.1.4: {}
-
-  electron-to-chromium@1.4.427: {}
+  dotenv@16.4.5: {}
 
   electron-to-chromium@1.5.27: {}
 
@@ -4660,7 +4645,7 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
-  fraction.js@4.2.0: {}
+  fraction.js@4.3.7: {}
 
   fs-extra@8.1.0:
     dependencies:
@@ -5349,6 +5334,8 @@ snapshots:
 
   nanoid@3.3.6: {}
 
+  nanoid@3.3.7: {}
+
   natural-compare-lite@1.4.0: {}
 
   natural-compare@1.4.0: {}
@@ -5392,8 +5379,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-
-  node-releases@2.0.12: {}
 
   node-releases@2.0.18: {}
 
@@ -5573,29 +5558,29 @@ snapshots:
 
   pirates@4.0.5: {}
 
-  postcss-import@15.1.0(postcss@8.4.24):
+  postcss-import@15.1.0(postcss@8.4.47):
     dependencies:
-      postcss: 8.4.24
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.2
 
-  postcss-js@4.0.1(postcss@8.4.24):
+  postcss-js@4.0.1(postcss@8.4.47):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.24
+      postcss: 8.4.47
 
-  postcss-load-config@4.0.1(postcss@8.4.24)(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3)):
+  postcss-load-config@4.0.1(postcss@8.4.47)(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.5.1
     optionalDependencies:
-      postcss: 8.4.24
-      ts-node: 10.9.1(@types/node@18.16.16)(typescript@5.1.3)
+      postcss: 8.4.47
+      ts-node: 10.9.1(@types/node@22.5.5)(typescript@5.1.3)
 
-  postcss-nested@6.0.1(postcss@8.4.24):
+  postcss-nested@6.0.1(postcss@8.4.47):
     dependencies:
-      postcss: 8.4.24
+      postcss: 8.4.47
       postcss-selector-parser: 6.0.13
 
   postcss-selector-parser@6.0.13:
@@ -5611,11 +5596,11 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  postcss@8.4.24:
+  postcss@8.4.47:
     dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
+      nanoid: 3.3.7
+      picocolors: 1.1.0
+      source-map-js: 1.2.1
 
   preact-render-to-string@5.2.6(preact@10.15.1):
     dependencies:
@@ -5858,6 +5843,8 @@ snapshots:
 
   source-map-js@1.0.2: {}
 
+  source-map-js@1.2.1: {}
+
   spawndamnit@2.0.0:
     dependencies:
       cross-spawn: 5.1.0
@@ -5949,7 +5936,7 @@ snapshots:
       pirates: 4.0.5
       ts-interface-checker: 0.1.13
 
-  superjson@1.9.1:
+  superjson@2.2.1:
     dependencies:
       copy-anything: 3.0.5
 
@@ -5970,15 +5957,15 @@ snapshots:
 
   tailwind-merge@1.14.0: {}
 
-  tailwindcss-animated@1.1.2(tailwindcss@3.4.12(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3))):
+  tailwindcss-animated@1.1.2(tailwindcss@3.4.12(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3))):
     dependencies:
-      tailwindcss: 3.4.12(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3))
+      tailwindcss: 3.4.12(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3))
 
-  tailwindcss-scrollbar@0.1.0(tailwindcss@3.4.12(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3))):
+  tailwindcss-scrollbar@0.1.0(tailwindcss@3.4.12(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3))):
     dependencies:
-      tailwindcss: 3.4.12(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3))
+      tailwindcss: 3.4.12(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3))
 
-  tailwindcss@3.4.12(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3)):
+  tailwindcss@3.4.12(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -5994,11 +5981,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.0
-      postcss: 8.4.24
-      postcss-import: 15.1.0(postcss@8.4.24)
-      postcss-js: 4.0.1(postcss@8.4.24)
-      postcss-load-config: 4.0.1(postcss@8.4.24)(ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3))
-      postcss-nested: 6.0.1(postcss@8.4.24)
+      postcss: 8.4.47
+      postcss-import: 15.1.0(postcss@8.4.47)
+      postcss-js: 4.0.1(postcss@8.4.47)
+      postcss-load-config: 4.0.1(postcss@8.4.47)(ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3))
+      postcss-nested: 6.0.1(postcss@8.4.47)
       postcss-selector-parser: 6.0.13
       resolve: 1.22.2
       sucrase: 3.32.0
@@ -6033,14 +6020,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.1(@types/node@18.16.16)(typescript@5.1.3):
+  ts-node@10.9.1(@types/node@22.5.5)(typescript@5.1.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.16.16
+      '@types/node': 22.5.5
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -6120,6 +6107,8 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
+  undici-types@6.19.8: {}
+
   unicorn-magic@0.1.0: {}
 
   unist-util-stringify-position@4.0.0:
@@ -6129,12 +6118,6 @@ snapshots:
   universalify@0.1.2: {}
 
   untildify@4.0.0: {}
-
-  update-browserslist-db@1.0.11(browserslist@4.21.7):
-    dependencies:
-      browserslist: 4.21.7
-      escalade: 3.1.1
-      picocolors: 1.0.0
 
   update-browserslist-db@1.1.0(browserslist@4.23.3):
     dependencies:
@@ -6252,3 +6235,5 @@ snapshots:
   yocto-queue@1.1.1: {}
 
   zod@3.21.4: {}
+
+  zod@3.23.8: {}


### PR DESCRIPTION
## Changes Made 🎉

- [x] chore: updated multiple dependencies in `package.json`

### Describe Changes

This PR updates several dependencies in both the `dependencies` and `devDependencies` sections of the `package.json` file. These updates include the following:

- Bumped `@tanstack/react-query` from `^4.29.2` to `^4.36.1`
- Bumped `superjson` from `1.9.1` to `2.2.1`
- Bumped `zod` from `^3.21.4` to `^3.23.8`
- Bumped `@types/node` from `^18.15.11` to `^22.5.5`
- Bumped `@types/react` from `^18.0.37` to `^18.3.8`
- Bumped `@types/react-dom` from `^18.0.11` to `^18.3.0`
- Bumped `autoprefixer` from `^10.4.14` to `^10.4.20`
- Bumped `dotenv-cli` from `^7.2.1` to `^7.4.2`
- Bumped `postcss` from `^8.4.22` to `^8.4.47`

### Related Issue(s)

None

## Visuals (Optional)

<!-- Add video or images showcasing the changes or demonstrating the functionality -->

## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
